### PR TITLE
Add .txt Exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ npm run dev
 
 ## Changelog
 
-### 2026-02-12 - Add CSV export
+### 2026-02-12 - Add CSV & TXT exports
 
 - Added "Export to .csv" button that downloads fixed JSON as a `.csv` file using `json-to-csv-export`
-- Added "Export to .txt File" button (logic TBD)
+- Added "Export to .txt File" button that downloads fixed JSON as a `.txt` file using `export-from-json`
 
 ### 2026-02-12 - Dependency cleanup and updates
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cost Estimation Tool</title>
+    <title>ESRI Exporter</title>
     <meta name="description" content="A React + TypeScript application using Tailwind CSS, DaisyUI, and Flask for cost estimation." />
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "export-from-json": "^1.7.4",
         "json-to-csv-export": "^3.1.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2133,6 +2134,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/export-from-json": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/export-from-json/-/export-from-json-1.7.4.tgz",
+      "integrity": "sha512-FjmpluvZS2PTYyhkoMfQoyEJMfe2bfAyNpa5Apa6C9n7SWUWyJkG/VFnzERuj3q9Jjo3iwBjwVsDQ7Z7sczthA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "export-from-json": "^1.7.4",
     "json-to-csv-export": "^3.1.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/components/form.component.tsx
+++ b/frontend/src/components/form.component.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import csvDownload from 'json-to-csv-export';
+import exportFromJSON from 'export-from-json';
 import './form.styles.css';
 
 interface FormProps {
@@ -125,7 +126,9 @@ const FormComponent: React.FC<FormProps> = ({ onSubmit }) => {
               <button
                 type="button"
                 className="copy-button"
-                onClick={() => {}}
+                onClick={() => {
+                  exportFromJSON({ data: JSON.parse(fixedJson), fileName: 'export', exportType: exportFromJSON.types.txt });
+                }}
               >
                 Export to .txt File
               </button>


### PR DESCRIPTION
- Added "Export to .txt File" button that downloads fixed JSON as a `.txt` file using `export-from-json`