### PR TITLE
Add Render deployment configuration for full-stack hosting

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,10 +8,7 @@ except ImportError:
     print("Flask not available. Install with: pip install flask flask-cors")
 
 import json
-
-# declare a new string named seattle with the value of seattle.txt
-with open("seattle.txt", "r") as f:
-    seattle = f.read()
+import os
 
 def fix_malformed_json(malformed_json_string):
     """
@@ -144,10 +141,12 @@ if FLASK_AVAILABLE:
 
 if __name__ == "__main__":
     if FLASK_AVAILABLE:
-        app.run(debug=True)
+        port = int(os.environ.get("PORT", 5000))
+        debug = os.environ.get("FLASK_DEBUG", "true").lower() == "true"
+        app.run(host="0.0.0.0", port=port, debug=debug)
     else:
         # Standalone usage example if Flask is not available
-        print("🔧 JSON Fixer - Standalone Mode")
+        print("JSON Fixer - Standalone Mode")
         print("Flask not installed. Running standalone example...\n")
 
         # Example usage

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.2
 Flask-Cors==3.0.10
+gunicorn==21.2.0

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,12 @@
   command = "npm install && npm run build"
   publish = "dist"
 
+# Return 404 for API routes since the backend is not hosted on Netlify
+[[redirects]]
+  from = "/api/*"
+  to = "/api-not-available"
+  status = 404
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,30 @@
+services:
+  # Flask backend API
+  - type: web
+    runtime: python
+    name: esri-exporter-api
+    rootDir: ./backend
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn app:app
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.11.6"
+      - key: FLASK_DEBUG
+        value: "false"
+
+  # React/Vite frontend static site
+  - type: web
+    runtime: static
+    name: esri-exporter-frontend
+    rootDir: ./frontend
+    buildCommand: npm install && npm run build
+    staticPublishPath: ./dist
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
+    # NOTE: After deploying, add a rewrite rule in the Render Dashboard:
+    #   Source: /api/*
+    #   Destination: https://esri-exporter-api.onrender.com/api/*
+    # This proxies frontend API calls to the backend service.
+    # Dashboard rewrites take priority over render.yaml routes.


### PR DESCRIPTION
The Flask backend was never deployed to Netlify (static-only host), causing "Backend API not found" errors in production. This adds Render Blueprint config to deploy both the backend web service and frontend static site from the same repo.

- Add gunicorn to requirements.txt for production WSGI server
- Remove unused seattle.txt file read that would crash on deploy
- Bind Flask to PORT env var and 0.0.0.0 for Render compatibility
- Create render.yaml defining both backend and frontend services
- Update netlify.toml to return 404 on /api/* instead of silently serving index.html