### PR TITLE
Fix backend URL in render.yaml and add changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ npm run dev
 
 ## Changelog
 
+### 2026-02-12 - Add Render deployment for full-stack hosting
+
+- Added Render Blueprint (`render.yaml`) to deploy both Flask backend and React frontend from the same monorepo
+- Added `gunicorn` as production WSGI server for the backend
+- Configured Flask to bind to Render's dynamic `PORT` environment variable
+- Removed unused `seattle.txt` file read that would crash on deploy
+- Updated `netlify.toml` to return 404 on `/api/*` routes instead of silently serving HTML
+
 ### 2026-02-12 - Add CSV & TXT exports
 
 - Added "Export to .csv" button that downloads fixed JSON as a `.csv` file using `json-to-csv-export`

--- a/render.yaml
+++ b/render.yaml
@@ -25,6 +25,6 @@ services:
         destination: /index.html
     # NOTE: After deploying, add a rewrite rule in the Render Dashboard:
     #   Source: /api/*
-    #   Destination: https://esri-exporter-api.onrender.com/api/*
+    #   Destination: https://esri-exporter.onrender.com/api/*
     # This proxies frontend API calls to the backend service.
     # Dashboard rewrites take priority over render.yaml routes.


### PR DESCRIPTION
## Summary
- Corrects the backend URL in `render.yaml` comment from `esri-exporter-api.onrender.com` to the actual deployed URL `esri-exporter.onrender.com`
- Adds Render deployment changelog entry to README

## Test plan
- [x] Verify render.yaml comment matches actual backend URL
- [x] Verify README changelog is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)