### PR TITLE
CrashMap Data Pipeline architecture planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .vercel
+
+# Claude
+.claude/
+CLAUDE.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,590 @@
+# CrashMap Data Pipeline — Architecture Guide
+
+> **CrashMap Data Pipeline** is a refactored version of the ESRI Exporter tool, purpose-built
+> to fetch crash data from the WSDOT collision REST API and convert it into SQL ready for
+> insertion into CrashMap's PostgreSQL database.
+
+---
+
+## 1. Introduction
+
+### Purpose
+
+The Washington State Department of Transportation (WSDOT) exposes bicyclist and pedestrian
+crash data through a public REST API (the ESRI map portal's data service). The response is a
+double-encoded JSON string that is not directly usable.
+
+This pipeline calls the WSDOT API from the backend, normalizes the JSON, maps fields to
+CrashMap's database schema, and outputs a `.sql` file containing batched `INSERT` statements
+ready to run against CrashMap's PostgreSQL database on Render.
+
+### Design Philosophy
+
+- **Stateless.** No database connection in the pipeline itself. The output is a portable `.sql`
+  file that the operator runs manually via `psql` or a GUI tool. Credentials never touch the
+  pipeline.
+- **Server-side fetching and processing.** The backend calls the WSDOT API directly — no
+  browser copy-paste required. Supports bulk multi-year imports.
+- **Non-destructive.** All inserts use `ON CONFLICT DO NOTHING`. Re-importing the same data
+  is always safe.
+- **Minimal dependencies.** SQL generation uses only Python's standard library. Only `requests`
+  is added for the WSDOT API calls.
+
+### Source → Destination
+
+```text
+WSDOT REST API
+(CrashDataPortalService.svc)
+         │  HTTP GET (from Flask backend)
+         ▼
+┌─────────────────────────────┐
+│   CrashMap Data Pipeline    │
+│   (ESRI Exporter — refact.) │
+│                             │
+│   React Frontend (Vite)     │  ← date range + mode UI
+│      + Flask Backend        │  ← fetches WSDOT, generates SQL
+└──────────────┬──────────────┘
+               │ .sql file download
+               ▼
+    Operator runs via psql
+               │
+               ▼
+┌──────────────────────────────┐
+│  CrashMap PostgreSQL + PostGIS│
+│  crashdata table (Render)    │
+└──────────────────────────────┘
+               │
+               ▼
+    REFRESH MATERIALIZED VIEW
+               │
+               ▼
+    CrashMap app (crashmap.io)
+    reflects new records
+```
+
+---
+
+## 2. Input Data Structure
+
+### WSDOT REST API
+
+The pipeline calls the WSDOT collision data REST API directly from the Flask backend.
+There is no export button on the portal — the data is fetched programmatically.
+
+**Endpoint:**
+
+```text
+GET https://remoteapps.wsdot.wa.gov/highwaysafety/collision/data/portal/public/
+    CrashDataPortalService.svc/REST/GetPublicPortalData
+```
+
+**Parameters:**
+
+| Parameter | Values | Notes |
+| --- | --- | --- |
+| `rptCategory` | `Pedestrians and Pedacyclists` | Same for both modes |
+| `rptName` | `Pedestrians by Injury Type` or `Bicyclists by Injury Type` | Driven by Mode selector |
+| `reportStartDate` | `YYYYMMDD` | e.g. `20250101` |
+| `reportEndDate` | `YYYYMMDD` | e.g. `20251231` |
+| `locationType` | *(empty)* | Optional geographic filter |
+| `locationName` | *(empty)* | Optional geographic filter |
+| `jurisdiction` | *(empty)* | Optional geographic filter |
+
+**Example — one year of statewide pedestrian data:**
+
+```text
+https://remoteapps.wsdot.wa.gov/highwaysafety/collision/data/portal/public/
+CrashDataPortalService.svc/REST/GetPublicPortalData
+?rptCategory=Pedestrians%20and%20Pedacyclists
+&rptName=Pedestrians%20by%20Injury%20Type
+&locationType=&locationName=&jurisdiction=
+&reportStartDate=20250101&reportEndDate=20251231
+```
+
+**Response size:** ~1.1 MB per year of statewide pedestrian data. The 10-year backfill
+(2015–2024, both modes) requires 20 API calls and generates roughly 22 MB of JSON total.
+
+**Workaround for development/testing:** If direct API calls are unavailable (network
+restrictions, API changes), the original text-paste / file-upload workflow still works.
+Paste or upload the raw response body copied from the browser DevTools Network tab.
+
+### Response Format
+
+The API returns a single-line, double-encoded JSON string wrapped in outer quotes.
+
+**Raw file content (abbreviated):**
+
+```text
+"\"[{\\\"ColliRptNum\\\":\\\"3838031\\\",\\\"Jurisdiction\\\":\\\"City Street\\\", ...}]\""
+```
+
+**After decoding** (what the array actually contains):
+
+```json
+[
+  {
+    "ColliRptNum": "3838031",
+    "Jurisdiction": "City Street",
+    "RegionName": "'",
+    "CountyName": "King",
+    "CityName": "Seattle",
+    "FullDate": "2025-02-21T00:00:00",
+    "FullTime": "11:06 AM",
+    "MostSevereInjuryType": "Suspected Minor Injury",
+    "AgeGroup": "",
+    "InvolvedPersons": 4,
+    "CrashStatePlaneX": 1192299.06,
+    "CrashStatePlaneY": 837515.73,
+    "Latitude": 47.615677169795,
+    "Longitude": -122.316864546986
+  }
+]
+```
+
+### Known Data Quality Issues
+
+| Field | Issue | Handling |
+|-------|-------|----------|
+| `RegionName` | Often contains `'` as a placeholder value | Normalize to `NULL` |
+| `AgeGroup` | Frequently empty string | Normalize empty string to `NULL` |
+| `ColliRptNum` | May appear in both ped and bike exports | Handled by `ON CONFLICT DO NOTHING` + pedestrian-first insertion order |
+| `CrashStatePlaneX/Y` | Present but not used by CrashMap | Dropped during field mapping |
+
+---
+
+## 3. Field Mapping: WSDOT → CrashMap
+
+CrashMap's `crashdata` table uses PascalCase quoted column names (a PostgreSQL convention
+inherited from the original Prisma schema introspection). All column names in INSERT
+statements must be double-quoted.
+
+### Complete Mapping
+
+| WSDOT Field             | CrashMap Column            | Type            | Notes                                          |
+|-------------------------|----------------------------|-----------------|------------------------------------------------|
+| `ColliRptNum`           | `"ColliRptNum"`            | String (PK)     | Primary key; drives conflict resolution        |
+| `Jurisdiction`          | `"Jurisdiction"`           | String          | Direct map                                     |
+| *(not in WSDOT)*        | `"StateOrProvinceName"`    | String          | Hardcoded `'Washington'` — WSDOT is WA-only    |
+| `RegionName`            | `"RegionName"`             | String          | `'` placeholder → `NULL`                       |
+| `CountyName`            | `"CountyName"`             | String          | Direct map                                     |
+| `CityName`              | `"CityName"`               | String          | Direct map                                     |
+| `FullDate`              | `"FullDate"`               | String          | ISO 8601: `2025-02-21T00:00:00`               |
+| `FullDate` (parsed)     | `"CrashDate"`              | Date            | Date portion only: `2025-02-21`               |
+| `FullTime`              | `"FullTime"`               | String          | Direct map                                     |
+| `MostSevereInjuryType`  | `"MostSevereInjuryType"`   | String          | Direct map                                     |
+| `AgeGroup`              | `"AgeGroup"`               | String          | Empty string → `NULL`                          |
+| `InvolvedPersons`       | `"InvolvedPersons"`        | SmallInt        | Integer                                        |
+| ~~`CrashStatePlaneX`~~  | *(dropped)*                | —               | Not used; CrashMap uses Lat/Long + PostGIS     |
+| ~~`CrashStatePlaneY`~~  | *(dropped)*                | —               | Not used; CrashMap uses Lat/Long + PostGIS     |
+| `Latitude`              | `"Latitude"`               | Double Precision| Direct map                                     |
+| `Longitude`             | `"Longitude"`              | Double Precision| Direct map                                     |
+| *(UI-selected)*         | `"Mode"`                   | String          | Manually set per export — see §4               |
+| *(computed)*            | `"geom"`                   | geometry        | `ST_SetSRID(ST_MakePoint(lng, lat), 4326)`     |
+
+---
+
+## 4. Mode Field
+
+### Why Mode Is Manual
+
+The WSDOT portal exports separate reports by victim type:
+
+- **"Pedestrians by Injury Type"** — all records are pedestrian crashes
+- **"Bicyclists by Injury Type"** — all records are bicyclist crashes
+
+The WSDOT API response contains **no field indicating the mode**. The operator selects
+the mode in the pipeline UI before fetching. The selected value is stamped onto every record
+during SQL generation.
+
+### Future Extensibility
+
+CrashMap may expand to include motor vehicle crashes. The Mode selector is an open dropdown
+(not hardcoded to two values) so that `"Motor Vehicle"` or other modes can be added to the
+UI without a backend code change.
+
+---
+
+## 5. SQL Generation Strategy
+
+### Statement Structure
+
+```sql
+INSERT INTO crashdata (
+  "ColliRptNum", "Jurisdiction", "StateOrProvinceName", "RegionName",
+  "CountyName", "CityName", "FullDate", "CrashDate", "FullTime",
+  "MostSevereInjuryType", "AgeGroup", "InvolvedPersons",
+  "Latitude", "Longitude", "Mode", "geom"
+) VALUES
+  (...),
+  (...)
+ON CONFLICT ("ColliRptNum") DO NOTHING;
+```
+
+### ON CONFLICT / Duplicate Handling
+
+The same `ColliRptNum` can appear in both the pedestrian and bicyclist exports when a single
+crash involves both a pedestrian and a bicyclist (e.g., a car hits a cyclist who was walking
+their bike). Both reports contain identical data except that the operator would have selected
+different modes.
+
+**Rule: the pedestrian record is authoritative.**
+
+- Always import the **pedestrian** `.sql` file first
+- Then import the **bicyclist** `.sql` file
+- `ON CONFLICT DO NOTHING` silently skips any `ColliRptNum` that already exists, regardless
+  of which file introduced it
+
+This means:
+
+- Cross-report duplicates are retained as pedestrian records
+- Re-importing the same file twice is always safe (idempotent)
+- The pipeline never overwrites an existing record
+
+### Batching
+
+Large exports are split into batches of 500 rows per INSERT statement. This prevents hitting
+PostgreSQL's parameter limit and keeps individual statements manageable in logs and query plans.
+Batch size is configurable via the API.
+
+### String Escaping
+
+All string values use manual `''` escaping (doubling single quotes). No external database
+driver is needed in the pipeline — the output is a plain text `.sql` file.
+
+Examples:
+
+- `O'Brien` → `'O''Brien'`
+- `""` (empty) → `NULL`
+- `'` (RegionName placeholder) → `NULL`
+
+### CrashDate Derivation
+
+`"CrashDate"` is a proper PostgreSQL `DATE` column used for range filtering in CrashMap.
+It is derived from `FullDate` by extracting the date portion:
+
+```text
+"2025-02-21T00:00:00"  →  '2025-02-21'
+```
+
+### PostGIS Geometry Column
+
+The `"geom"` column uses the PostGIS `geometry` type with SRID 4326 (WGS 84 / GPS coordinates).
+Every INSERT includes an explicit geometry value:
+
+```sql
+ST_SetSRID(ST_MakePoint(<longitude>, <latitude>), 4326)
+```
+
+Note the argument order: **longitude first**, then latitude — this is the PostGIS convention
+(x, y = lng, lat).
+
+### Sample Output
+
+```sql
+-- CrashMap Data Pipeline Output
+-- Mode: Pedestrian | Source: WSDOT ESRI Export | Generated: 2026-02-24
+-- Total records: 7
+
+INSERT INTO crashdata (
+  "ColliRptNum", "Jurisdiction", "StateOrProvinceName", "RegionName",
+  "CountyName", "CityName", "FullDate", "CrashDate", "FullTime",
+  "MostSevereInjuryType", "AgeGroup", "InvolvedPersons",
+  "Latitude", "Longitude", "Mode", "geom"
+) VALUES
+  ('3838031', 'City Street', 'Washington', NULL, 'King', 'Seattle',
+   '2025-02-21T00:00:00', '2025-02-21', '11:06 AM', 'Suspected Minor Injury',
+   NULL, 4, 47.615677169795, -122.316864546986,
+   'Pedestrian', ST_SetSRID(ST_MakePoint(-122.316864546986, 47.615677169795), 4326)),
+  ('3887523', 'City Street', 'Washington', NULL, 'King', 'Seattle',
+   '2025-02-01T00:00:00', '2025-02-01', '1:20 AM', 'Died in Hospital',
+   NULL, 2, 47.668680009423, -122.376289485757,
+   'Pedestrian', ST_SetSRID(ST_MakePoint(-122.376289485757, 47.668680009423), 4326))
+ON CONFLICT ("ColliRptNum") DO NOTHING;
+```
+
+---
+
+## 6. Application Architecture
+
+### System Overview
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│                  React Frontend (Vite)                   │
+│                                                          │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │               form.component.tsx                  │   │
+│  │                                                   │   │
+│  │  [Mode ▼]  [Start Year ▼]  [End Year ▼]           │   │
+│  │                                                   │   │
+│  │  [Fetch from WSDOT & Generate SQL]                │   │
+│  │                                                   │   │
+│  │  Preview: <first 50 lines>   Records: N           │   │
+│  │  [Download .sql]  [Debug: View JSON ▼]            │   │
+│  │                                                   │   │
+│  │  ── Fallback tab ──────────────────────────────   │   │
+│  │  [Paste / Upload raw response]                    │   │
+│  └─────────────────────────┬─────────────────────────┘   │
+└────────────────────────────┼────────────────────────────┘
+                             │ POST /api/fetch-and-generate-sql
+                             │ application/json
+                             ▼
+┌─────────────────────────────────────────────────────────┐
+│                  Flask Backend (Python)                  │
+│                                                          │
+│  POST /api/fetch-and-generate-sql                        │
+│    1. Build WSDOT URL from mode + date range             │
+│    2. requests.get(wsdot_url) → raw response             │
+│    3. fix_malformed_json()  ← reused unchanged           │
+│    4. json.loads() → list of crash dicts                 │
+│    5. generate_sql(records, mode, batch_size)            │
+│    6. Return .sql as file download                       │
+│                                                          │
+│  POST /api/generate-sql  (fallback: file/paste upload)   │
+│  POST /api/fix-json       (debug utility)                │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Tech Stack
+
+| Layer | Technology | Version |
+|-------|-----------|---------|
+| Frontend | React + TypeScript | 18.x / 5.x |
+| Build tool | Vite | 6.x |
+| Styling | TailwindCSS | 3.x |
+| Backend | Python + Flask | 3.11 / 2.3 |
+| Production server | Gunicorn | 21.x |
+| Hosting | Render (full-stack) | — |
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `backend/app.py` | Flask app — JSON fixer + SQL generator |
+| `backend/test_json_fixer.py` | Unit tests |
+| `backend/seattle short.txt` | Sample malformed JSON for testing |
+| `frontend/src/components/form.component.tsx` | Main UI component |
+| `render.yaml` | Full-stack Render deployment config |
+
+---
+
+## 7. API Reference
+
+### Existing: `POST /api/fix-json`
+
+Retained for debugging raw JSON output.
+
+**Request:**
+
+```json
+{ "malformed_json": "<raw .txt file content>" }
+```
+
+**Response:**
+
+```json
+{ "fixed_json": "<pretty-printed JSON>", "message": "JSON successfully formatted" }
+```
+
+### New: `POST /api/fetch-and-generate-sql` (primary)
+
+Calls the WSDOT API from the backend — no file upload needed.
+
+**Request:** `application/json`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mode` | String | Yes | `"Pedestrian"`, `"Bicyclist"`, or other |
+| `start_date` | String | Yes | `YYYYMMDD` — e.g. `"20250101"` |
+| `end_date` | String | Yes | `YYYYMMDD` — e.g. `"20251231"` |
+| `batch_size` | Integer | No | Rows per INSERT (default: 500) |
+
+**Response 200:**
+
+```text
+Content-Type: application/sql
+Content-Disposition: attachment; filename="crashmap_import_2026-02-24.sql"
+
+<SQL file content>
+```
+
+**Response 400:** `{ "error": "Missing required field: mode" }`
+
+**Response 502:** `{ "error": "WSDOT API request failed: <message>" }`
+
+### New: `POST /api/generate-sql` (fallback — file/paste upload)
+
+For cases where direct API fetch is unavailable.
+
+**Request:** `multipart/form-data`
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `file` | File (.txt) | Yes | Raw WSDOT response saved as file |
+| `mode` | String | Yes | `"Pedestrian"`, `"Bicyclist"`, or other |
+| `batch_size` | Integer | No | Rows per INSERT (default: 500) |
+
+**Response 200:** Same `.sql` file download as primary endpoint.
+
+**Response 400:** `{ "error": "Missing required field: mode" }`
+
+**Response 500:** `{ "error": "Failed to parse JSON: <message>" }`
+
+---
+
+## 8. Development Phases
+
+Hours per week are TBD based on team availability. Phases are ordered by dependency;
+phases 1–3 must complete before 4–6.
+
+### Phase 1 — Foundation & Field Mapping
+
+**Goal:** Working `generate_sql()` function with unit tests.
+
+- Audit `fix_malformed_json()` for large-file robustness (currently processes strings
+  in memory; no changes expected for files up to ~50MB)
+- Implement `generate_sql(records, mode, batch_size=500) → str` in `backend/app.py`
+- Implement field mapping: NULL coercion, `'` sanitization, string escaping, `CrashDate`
+  derivation, `geom` generation
+- Add unit tests to `backend/test_json_fixer.py` covering:
+  - Basic mapping with sample data
+  - NULL coercion (empty string, `'` placeholder)
+  - String escaping (apostrophes in city/county names)
+  - Batch splitting
+  - Known-duplicate `ColliRptNum` across two imports
+
+### Phase 2 — Backend API
+
+**Goal:** Tested Flask endpoint returning a valid `.sql` file.
+
+- Implement `POST /api/generate-sql` in `backend/app.py`
+- Accept `multipart/form-data` file upload (replaces JSON body for this endpoint)
+- Return SQL as `Content-Disposition: attachment` response
+- Validate required `mode` field; return 400 if missing
+- Extend test suite
+
+### Phase 3 — Frontend Refactor
+
+**Goal:** Working end-to-end UI in local dev.
+
+- Replace textarea input with `<input type="file" accept=".txt">` in `form.component.tsx`
+- Add Mode selector (combobox or `<select>` with `Pedestrian`, `Bicyclist` as defaults;
+  allow free-text entry for future modes)
+- Add State field (pre-filled `Washington`, editable)
+- Wire file upload to `POST /api/generate-sql` via `FormData`
+- Show SQL preview (first 50 lines) and record count
+- Add "Download .sql" button via Blob URL
+- Retain "Debug: View Fixed JSON" as a collapsible section (still calls `/api/fix-json`)
+
+### Phase 4 — Large File Handling
+
+**Goal:** Pipeline handles statewide WSDOT exports without timeout.
+
+- Profile with full county/statewide exports (estimated 10k–100k records)
+- If memory is a concern: stream file in chunks before parsing
+- Add progress indicator to frontend (indeterminate spinner during server processing)
+- Adjust Render service timeout if needed (default: 30s; may need 120s for large files)
+
+### Phase 5 — Documentation
+
+**Goal:** `ARCHITECTURE.md` and `TUTORIAL.md` complete and reviewed.
+
+- `ARCHITECTURE.md` (this file) — technical reference for developers
+- `TUTORIAL.md` — step-by-step operator guide for importing data
+
+### Phase 6 — Testing & Hardening
+
+**Goal:** Production-ready pipeline deployed to Render.
+
+- End-to-end test with real WSDOT exports for both modes
+- Verify `DO NOTHING` behavior with known-duplicate `ColliRptNum` values
+- Edge cases: `RegionName: "'"`, empty `AgeGroup`, extreme lat/long values
+- Deploy to Render, validate `.sql` downloads and CrashMap materialized view refresh
+
+---
+
+## 9. Suggested Libraries and Tools
+
+### Backend (Python — one new pip dependency: `requests`)
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `requests` | WSDOT API calls | Add to `backend/requirements.txt` |
+| `json` (stdlib) | JSON parsing | Already used in `fix_malformed_json()` |
+| `io` / `werkzeug` | File upload handling (fallback) | Flask provides via `request.files` |
+| `datetime` (stdlib) | Date formatting | For header comment timestamps |
+| `re` (stdlib) | String sanitization | For `RegionName` placeholder detection |
+
+### Frontend (no new npm packages required)
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| `Blob` + `URL.createObjectURL` | SQL file download | Already used pattern for CSV/TXT export |
+| React `useState` | File and mode state | Existing pattern in `form.component.tsx` |
+
+### Operator Tools (external)
+
+| Tool | Purpose |
+|------|---------|
+| `psql` | Execute `.sql` file against Render PostgreSQL |
+| pgAdmin / TablePlus / DBeaver | GUI alternative to `psql` for running SQL files |
+| PostGIS (already on Render DB) | Provides `ST_MakePoint`, `ST_SetSRID` functions |
+
+---
+
+## 10. Post-Import Runbook
+
+After executing the `.sql` file against CrashMap's Render database, run the following
+to make new records visible in the app. See `TUTORIAL.md` for the full step-by-step guide.
+
+```sql
+-- Refresh both materialized views
+REFRESH MATERIALIZED VIEW filter_metadata;
+REFRESH MATERIALIZED VIEW available_years;
+```
+
+**Verify the import:**
+
+```sql
+-- Check record count by mode and year
+SELECT "Mode", EXTRACT(YEAR FROM "CrashDate") AS year, COUNT(*)
+FROM crashdata
+GROUP BY "Mode", year
+ORDER BY year DESC, "Mode";
+```
+
+CrashMap's filter dropdowns (counties, cities, years) are populated from these materialized
+views. They will not reflect new data until both views are refreshed.
+
+---
+
+## 11. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Large files cause Render request timeout | High | High | Chunked reads; raise Render service timeout to 120s; add progress indicator |
+| WSDOT export format adds or removes fields | Medium | High | Schema validation before SQL gen; log unknown fields as warnings |
+| `RegionName: "'"` data quality issue | High | Low | Normalize any value that is only whitespace or `'` → `NULL` |
+| SQL injection via crash data string values | Low | High | `''` escaping on all string values; never interpolate raw values via f-strings |
+| Operator runs bicyclist import before pedestrian | Medium | Medium | Warn prominently in TUTORIAL.md; consider a pipeline-level UI warning prompt |
+| PostGIS `ST_MakePoint` fails on bad coordinates | Low | Medium | Validate lat/long ranges before generating SQL; skip records with `NULL` coordinates |
+| Mode selected incorrectly for uploaded file | Medium | High | Show record count and sample data in preview before download; require explicit confirmation |
+| Render DB PostGIS extension not enabled | Low | High | Verify once with `SELECT PostGIS_Version();`; document in TUTORIAL.md setup checklist |
+
+---
+
+## 12. Relationship to CrashMap
+
+This pipeline feeds into CrashMap's data tier. Key CrashMap architectural details relevant
+to this pipeline:
+
+- **Table:** `crashdata` — single PostgreSQL table with PascalCase quoted column names
+- **Primary key:** `"ColliRptNum"` (String)
+- **Spatial index:** `idx_crashdata_geom` (GIST) on the `"geom"` column
+- **Mode values:** CrashMap queries use `"Bicyclist"` and `"Pedestrian"` exactly — case matters
+- **Severity mapping:** CrashMap maps raw `"MostSevereInjuryType"` values to display buckets
+  (`Death`, `Major Injury`, `Minor Injury`, `None`) in its resolver layer — insert raw strings as-is
+- **Materialized views:** `filter_metadata` and `available_years` must be refreshed after import
+- **PostGIS:** Required for the `"geom"` column; already enabled on the Render database
+
+CrashMap source: <https://github.com/nickmagruder/crashmap>

--- a/README.md
+++ b/README.md
@@ -36,15 +36,14 @@ A simple template for building full-stack applications with Python and React.
 1. Navigate to the `backend` directory:
 
 ```bash
-   cd backend
+cd backend
 ```
 
-1. Create and activate a virtual environment
+1. Create and activate a virtual environment:
 
 ```bash
-`python3 -m venv venv` OR `python -m venv venv`
-
-source venv/bin/activate  # On Windows: `venv\Scripts\activate`
+python3 -m venv venv  # or: python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
 ```
 
 1. Install dependencies:
@@ -88,10 +87,18 @@ npm run dev
 
 ### Usage
 
- • Backend: **<http://127.0.0.1:5000>**
- • Frontend: **<http://127.0.0.1:5173>**
+- Backend: **<http://127.0.0.1:5000>**
+- Frontend: **<http://127.0.0.1:5173>**
 
 ## Changelog
+
+### 2026-02-24 - CrashMap Data Pipeline architecture planning
+
+- Added `ARCHITECTURE.md` — technical reference for the CrashMap Data Pipeline refactor:
+  field mapping, SQL generation strategy, WSDOT API details, duplicate handling, development phases, and risk register
+- Added `TUTORIAL.md` — step-by-step operator guide: fetch from WSDOT, generate SQL, import to Render PostgreSQL, refresh materialized views
+- Confirmed WSDOT `GetPublicPortalData` REST API is publicly accessible with no authentication (both pedestrian and bicyclist endpoints verified)
+- Pipeline design: backend calls WSDOT API directly via `requests`; no browser copy-paste required; DevTools paste retained as fallback
 
 ### 2026-02-12 - Add Render deployment for full-stack hosting
 
@@ -126,6 +133,6 @@ npm run dev
 - Fixed build command for Netlify Deloyment
 - Updated Readme
 
-### License
+## License
 
 This project is licensed under the MIT License.

--- a/STARTHERE.md
+++ b/STARTHERE.md
@@ -27,7 +27,7 @@ A simple template for building full-stack applications with Python and React.
    cd backend
 ```
 
-2. Create and activate a virtual environment
+1. Create and activate a virtual environment
 
 ```bash
 `python3 -m venv venv` OR `python -m venv venv`
@@ -35,7 +35,7 @@ A simple template for building full-stack applications with Python and React.
 source venv/bin/activate  # On Windows: `venv\Scripts\activate`
 ```
 
-3. Install dependencies:
+1. Install dependencies:
 
 ```bash
 pip install -r requirements.txt
@@ -48,7 +48,7 @@ which python
 which pip
 ```
 
-4. Run the Flask app:
+1. Run the Flask app:
 
 ```bash
 flask run
@@ -62,13 +62,13 @@ flask run
 cd frontend
 ```
 
-2. Install dependencies:
+1. Install dependencies:
 
 ```bash
 npm install
 ```
 
-3. Start the development server:
+1. Start the development server:
 
 ```bash
 npm run dev

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,333 @@
+# CrashMap Data Pipeline — Operator Tutorial
+
+> This guide walks through the complete process of downloading crash data from the WSDOT
+> portal, generating SQL with the CrashMap Data Pipeline, and importing it into CrashMap's
+> database.
+
+---
+
+## Overview
+
+The full workflow has four stages:
+
+1. **Fetch** — The pipeline calls the WSDOT API directly; you select mode and date range in the UI
+2. **Generate** — The pipeline converts the response to SQL and offers a `.sql` file download
+3. **Import** — Run the `.sql` file against CrashMap's PostgreSQL database
+4. **Refresh** — Refresh CrashMap's materialized views so new data appears in the app
+
+> **Important — always import Pedestrian data first, then Bicyclist.**
+> Some crashes appear in both reports. The pipeline uses `ON CONFLICT DO NOTHING`, so
+> whichever report is imported first "wins." Pedestrian is the canonical record for shared
+> crashes.
+
+---
+
+## Stage 1: Fetch Data from WSDOT
+
+The pipeline calls the WSDOT REST API directly from the backend — no browser export,
+no copy-paste required.
+
+### 1.1 Open the CrashMap Data Pipeline
+
+Navigate to the deployed pipeline app (Render URL) or run it locally:
+
+```bash
+# Local development
+cd backend && python app.py
+# In another terminal:
+cd frontend && npm run dev
+# Open http://localhost:5173
+```
+
+### 1.2 Select the mode
+
+In the **Mode** dropdown, select:
+
+- `Pedestrian` — fetches "Pedestrians by Injury Type"
+- `Bicyclist` — fetches "Bicyclists by Injury Type"
+
+> **Double-check the mode.** Every record in the `.sql` file is stamped with the selected
+> mode. Fetching bicyclist data while `Pedestrian` is selected will mislabel all records.
+
+### 1.3 Set the date range
+
+Enter a **Start Date** and **End Date**. The WSDOT tool goes back 10 years.
+
+For the initial 10-year backfill, use the **Bulk Import** option and select a start year
+and end year. The pipeline will loop through each year automatically and generate a single
+combined `.sql` file.
+
+> **Tip:** For the initial backfill, run Pedestrian for all 10 years first, then Bicyclist.
+
+### 1.4 Generate and download
+
+Click **Generate SQL**. The backend will:
+
+1. Call the WSDOT API for the selected mode and date range
+2. Decode the double-encoded JSON response
+3. Map all fields to CrashMap's schema
+4. Generate batched `INSERT ... ON CONFLICT DO NOTHING` statements
+5. Return a `.sql` file download
+
+Review the **preview** (first 50 lines) and **record count** before proceeding.
+
+Click **Download .sql** to save the file (e.g., `crashmap_pedestrian_2015-2024.sql`).
+
+### 1.5 Repeat for the other mode
+
+Run the full workflow a second time with the other mode selected.
+
+Always import the Pedestrian `.sql` file before the Bicyclist `.sql` file.
+
+---
+
+### Fallback: Manual Copy from DevTools
+
+If the direct API fetch is unavailable (network restrictions, API changes, testing), you
+can manually copy the response from the browser and paste it into the pipeline.
+
+1. Open the WSDOT portal in a browser
+2. Open **DevTools** → **Network** tab
+3. Apply your filters (date range, report type) and trigger the data load
+4. Find the `GetPublicPortalData` request in the Network tab
+5. Click it → **Response** tab → select all → copy
+6. In the pipeline, use the **Paste JSON** tab instead of the Fetch tab
+7. Select the correct Mode and proceed as normal
+
+The raw response is a single line of double-encoded JSON — this is expected.
+
+---
+
+## Stage 2: Generate SQL
+
+Stage 2 is handled automatically inside Stage 1. When you click **Fetch from WSDOT &
+Generate SQL**, the backend fetches the data, decodes the JSON, maps the fields, and
+streams the resulting `.sql` file back to your browser in a single step.
+
+There is no separate "generate" step — the download is the output of the fetch.
+
+---
+
+## Stage 3: Import into CrashMap's Database
+
+### 3.1 Get the database connection string
+
+The `DATABASE_URL` for CrashMap's Render PostgreSQL is stored in the Render dashboard
+environment variables. It looks like:
+
+```text
+postgresql://user:password@hostname.render.com:5432/dbname?sslmode=require
+```
+
+> **Never commit this value to git.** Copy it temporarily into your terminal session only.
+
+### 3.2 Run the SQL file
+
+#### Option A — `psql` (command line)
+
+```bash
+psql "$DATABASE_URL" -f crashmap_import_2026-02-24.sql
+```
+
+You should see output like:
+
+```text
+INSERT 0 500
+INSERT 0 500
+INSERT 0 432
+```
+
+Each line corresponds to one batch. The number after `INSERT 0` is the rows inserted
+(not skipped by `ON CONFLICT`). A count of `0` on re-import is normal and expected.
+
+#### Option B — GUI tool (pgAdmin, TablePlus, DBeaver)
+
+1. Connect to the Render database using the connection string
+2. Open a Query window
+3. Open or paste the `.sql` file contents
+4. Execute
+
+### 3.3 Verify the import
+
+Run a quick check to confirm records were inserted:
+
+```sql
+SELECT "Mode", EXTRACT(YEAR FROM "CrashDate") AS year, COUNT(*)
+FROM crashdata
+GROUP BY "Mode", year
+ORDER BY year DESC, "Mode";
+```
+
+Expected: new rows visible for the mode and year(s) you imported.
+
+Also spot-check a specific record from your source data:
+
+```sql
+SELECT * FROM crashdata WHERE "ColliRptNum" = '3838031';
+```
+
+---
+
+## Stage 4: Refresh CrashMap Materialized Views
+
+CrashMap's filter dropdowns (counties, cities, years) are populated from two materialized
+views. **These must be refreshed manually after every import.** Until you refresh them,
+new records will appear on the map but may not show in filters.
+
+### 4.1 Run the refresh
+
+```sql
+REFRESH MATERIALIZED VIEW filter_metadata;
+REFRESH MATERIALIZED VIEW available_years;
+```
+
+Run these in the same `psql` session or GUI tool used in Stage 3.
+
+### 4.2 Verify the refresh
+
+```sql
+-- Check that new counties/cities appear
+SELECT DISTINCT county FROM filter_metadata ORDER BY county;
+
+-- Check that new years appear
+SELECT year FROM available_years ORDER BY year DESC;
+```
+
+### 4.3 Check the CrashMap app
+
+Open CrashMap and verify:
+
+- New records appear as dots on the map
+- Year filter includes newly imported year(s)
+- County and city filters include newly imported locations
+
+---
+
+## Full Import Checklist
+
+Use this checklist each time you import new data.
+
+### Pedestrian Import
+
+- [ ] Open CrashMap Data Pipeline
+- [ ] Set Mode = `Pedestrian`
+- [ ] Set date range (e.g. `20250101` – `20251231`; or use Bulk Import for multi-year)
+- [ ] Click **Fetch from WSDOT & Generate SQL** — review preview + record count
+- [ ] Download `.sql` file
+- [ ] Run `.sql` against Render PostgreSQL: `psql "$DATABASE_URL" -f <file>.sql`
+- [ ] Confirm insert counts in psql output
+- [ ] Spot-check a record in the database
+
+### Bicyclist Import (run after Pedestrian)
+
+- [ ] Open CrashMap Data Pipeline
+- [ ] Set Mode = `Bicyclist`
+- [ ] Set same date range as Pedestrian import
+- [ ] Click **Fetch from WSDOT & Generate SQL** — review preview + record count
+- [ ] Download `.sql` file
+- [ ] Run `.sql` against Render PostgreSQL: `psql "$DATABASE_URL" -f <file>.sql`
+- [ ] Confirm insert counts (some `0` rows expected for cross-report duplicates)
+
+### After Both Imports
+
+- [ ] `REFRESH MATERIALIZED VIEW filter_metadata;`
+- [ ] `REFRESH MATERIALIZED VIEW available_years;`
+- [ ] Verify new records visible in CrashMap app
+- [ ] Verify year and location filters updated
+
+---
+
+## Troubleshooting
+
+### "Failed to parse JSON" or "WSDOT API request failed" error
+
+**Direct fetch path:** The WSDOT API may be temporarily unavailable or the date range
+may have returned an empty response. Try a narrower date range, or wait and retry.
+Use the DevTools fallback (see Stage 1) if the API is consistently unreachable.
+
+**Fallback paste/upload path:** The pasted or uploaded content may be incomplete.
+Copy the full response again from the DevTools Network tab — ensure you selected all
+text in the Response panel. Do not open or edit the file in a text editor, as some
+editors reformat or trim content.
+
+### psql: SSL connection required
+
+Add `?sslmode=require` to your connection string if it's not already present. Render
+requires SSL for all external connections.
+
+### psql: permission denied for table crashdata
+
+You are connecting with the wrong database user or to the wrong database. Check the
+`DATABASE_URL` in the Render dashboard.
+
+### Records imported but don't appear on the map
+
+The materialized views need refreshing. Run:
+
+```sql
+REFRESH MATERIALIZED VIEW filter_metadata;
+REFRESH MATERIALIZED VIEW available_years;
+```
+
+Then hard-refresh the CrashMap browser tab (`Ctrl+Shift+R` / `Cmd+Shift+R`).
+
+### Duplicate records (same crash in both ped and bike reports)
+
+This is expected behavior, not an error. The pipeline uses `ON CONFLICT DO NOTHING` to
+handle this silently. As long as the pedestrian import ran first, the duplicate will be
+stored as a pedestrian record and the bicyclist insert will be skipped. You may see
+`INSERT 0 N` lines in the psql output where `N` is less than the batch size — this is normal.
+
+### Wrong mode selected for a file
+
+If you realize you imported a bicyclist file as "Pedestrian" (or vice versa), the
+affected records must be updated manually:
+
+```sql
+-- Fix mode for specific collision report numbers
+UPDATE crashdata
+SET "Mode" = 'Bicyclist'
+WHERE "ColliRptNum" IN ('3838031', '3887523', ...);
+```
+
+Or, if the entire import needs to be redone, delete the affected records and re-import
+with the correct mode:
+
+```sql
+-- Remove all records from a specific import date range with wrong mode
+DELETE FROM crashdata
+WHERE "Mode" = 'Pedestrian'
+  AND "CrashDate" BETWEEN '2025-01-01' AND '2025-12-31'
+  AND "ColliRptNum" IN (<list of affected ColliRptNums>);
+```
+
+Then refresh the materialized views and re-import with the correct mode.
+
+---
+
+## Local Development Setup
+
+To run the pipeline locally:
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/nickmagruder/esri-exporter.git
+cd esri-exporter
+
+# 2. Backend
+cd backend
+python -m venv venv
+source venv/bin/activate   # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+python app.py              # Runs on http://localhost:5000
+
+# 3. Frontend (new terminal)
+cd frontend
+npm install
+npm run dev                # Runs on http://localhost:5173
+```
+
+The Vite dev server proxies `/api/*` requests to the Flask backend automatically.
+
+Test with the included sample file: `backend/seattle short.txt` — select Mode = `Bicyclist`,
+click Generate SQL, and verify the output matches the expected field mapping in `ARCHITECTURE.md`.


### PR DESCRIPTION
- Added `ARCHITECTURE.md` — technical reference for the CrashMap Data Pipeline refactor: field mapping, SQL generation strategy, WSDOT API details, duplicate handling, development phases, and risk register
- Added `TUTORIAL.md` — step-by-step operator guide: fetch from WSDOT, generate SQL, import to Render PostgreSQL, refresh materialized views
- Confirmed WSDOT `GetPublicPortalData` REST API is publicly accessible with no authentication (both pedestrian and bicyclist endpoints verified)
- Pipeline design: backend calls WSDOT API directly via `requests`; no browser copy-paste required; DevTools paste retained as fallback

Closes #12 