### PR TITLE
Implement `generate_sql()`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -281,9 +281,10 @@ Note the argument order: **longitude first**, then latitude — this is the Post
 ### Sample Output
 
 ```sql
--- CrashMap Data Pipeline Output
--- Mode: Pedestrian | Source: WSDOT ESRI Export | Generated: 2026-02-24
--- Total records: 7
+-- CrashMap Data Import
+-- Mode: Pedestrian
+-- Generated: 2026-02-24
+-- Records: 7
 
 INSERT INTO crashdata (
   "ColliRptNum", "Jurisdiction", "StateOrProvinceName", "RegionName",
@@ -513,7 +514,6 @@ phases 1–3 must complete before 4–6.
 | `json` (stdlib) | JSON parsing | Already used in `fix_malformed_json()` |
 | `io` / `werkzeug` | File upload handling (fallback) | Flask provides via `request.files` |
 | `datetime` (stdlib) | Date formatting | For header comment timestamps |
-| `re` (stdlib) | String sanitization | For `RegionName` placeholder detection |
 
 ### Frontend (no new npm packages required)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ESRI Exporter
+**Version:** 0.1.0
 
 An application for capturing and converting map data from ESRI map applications. Currently, this application works just for capturing crash data from the WSDOT ESRI map for the purposed of reusing the data in a more full-featured app I'm building called CrashMap.
 
@@ -91,6 +92,12 @@ npm run dev
 - Frontend: **<http://127.0.0.1:5173>**
 
 ## Changelog
+
+### 2026-02-24 - Implement `generate_sql()` (Phase 1)
+
+- Implemented `generate_sql(records, mode, batch_size=500)` in `backend/app.py`
+- Full WSDOT → CrashMap field mapping: NULL coercion, apostrophe escaping, `CrashDate` derivation, PostGIS `geom` generation
+- Batched `INSERT ... ON CONFLICT ("ColliRptNum") DO NOTHING` output with header comment block
 
 ### 2026-02-24 - CrashMap Data Pipeline architecture planning
 


### PR DESCRIPTION
- Implemented `generate_sql(records, mode, batch_size=500)` in `backend/app.py`
- Full WSDOT → CrashMap field mapping: NULL coercion, apostrophe escaping, `CrashDate` derivation, PostGIS `geom` generation
- Batched `INSERT ... ON CONFLICT ("ColliRptNum") DO NOTHING` output with header comment block

Closes #14 