### PR TITLE
Implement `POST /api/fetch-and-generate-sql` (Phase 2 complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ESRI Exporter
-**Version:** 0.1.1
-**Version:** 0.1.1
+**Version:** 0.2.0
 
 An application for capturing and converting map data from ESRI map applications. Currently, this application works just for capturing crash data from the WSDOT ESRI map for the purposed of reusing the data in a more full-featured app I'm building called CrashMap.
 
@@ -99,13 +98,21 @@ npm run dev
 - Added 6 `assert`-based unit tests to `backend/test_json_fixer.py` covering field mapping, NULL coercion (`'` placeholder and empty string), apostrophe escaping, batch splitting, and duplicate `ColliRptNum` / `DO NOTHING` behavior
 - Tests use `backend/seattle short.txt` as a real-data fixture and are runnable via `python test_json_fixer.py` or `pytest`
 
-### 2026-02-24 - Implement `POST /api/generate-sql` (Phase 2, partial)
+### 2026-02-24 - Implement `POST /api/fetch-and-generate-sql` (Phase 2 complete)
+
+- Implemented `POST /api/fetch-and-generate-sql` endpoint in `backend/app.py`
+- Calls WSDOT `GetPublicPortalData` REST API directly from the backend using `requests`
+- Maps `Pedestrian` → `Pedestrians by Injury Type` and `Bicyclist` → `Bicyclists by Injury Type` for WSDOT `rptName` param
+- Returns `.sql` as `Content-Disposition: attachment` file download; 400 for missing/unrecognized fields, 502 for WSDOT API failures
+- Added `requests==2.32.3` to `backend/requirements.txt`
+- Bumped version to 0.2.0
+
+### 2026-02-24 - Implement `POST /api/generate-sql`
 
 - Implemented `POST /api/generate-sql` endpoint in `backend/app.py`
 - Accepts `multipart/form-data` with a `.txt` file upload, `mode`, and optional `batch_size`
 - Runs file content through `fix_malformed_json()` → `generate_sql()` → returns `.sql` as a `Content-Disposition: attachment` file download
 - Returns 400 for missing `mode` or `file`; 500 for JSON parse failures
-- Bumped version to 0.1.1
 
 ### 2026-02-24 - Implement `generate_sql()` (Phase 1)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.2
 Flask-Cors==3.0.10
 gunicorn==21.2.0
+requests==2.32.3


### PR DESCRIPTION
- Implemented `POST /api/fetch-and-generate-sql` endpoint in `backend/app.py`
- Calls WSDOT `GetPublicPortalData` REST API directly from the backend using `requests`
- Maps `Pedestrian` → `Pedestrians by Injury Type` and `Bicyclist` → `Bicyclists by Injury Type` for WSDOT `rptName` param
- Returns `.sql` as `Content-Disposition: attachment` file download; 400 for missing/unrecognized fields, 502 for WSDOT API failures
- Added `requests==2.32.3` to `backend/requirements.txt`
- Bumped version to 0.2.0

Closes #19 