### PR TITLE
mode selector + date range pickers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -316,7 +316,7 @@ ON CONFLICT ("ColliRptNum") DO NOTHING;
 │  ┌──────────────────────────────────────────────────┐   │
 │  │               form.component.tsx                  │   │
 │  │                                                   │   │
-│  │  [Mode ▼]  [Start Year ▼]  [End Year ▼]           │   │
+│  │  [Mode ▼]  [Start Date]  [End Date]                 │   │
 │  │                                                   │   │
 │  │  [Fetch from WSDOT & Generate SQL]                │   │
 │  │                                                   │   │

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ESRI Exporter
-**Version:** 0.2.0
+
+**Version:** 0.3.0
 
 An application for capturing and converting map data from ESRI map applications. Currently, this application works just for capturing crash data from the WSDOT ESRI map for the purposed of reusing the data in a more full-featured app I'm building called CrashMap.
 
@@ -93,10 +94,14 @@ npm run dev
 
 ## Changelog
 
-### 2026-02-24 - Add unit tests for `generate_sql()` (Phase 1 complete)
+### 2026-02-24 - Frontend refactor: mode selector + date range pickers (Phase 3, partial)
 
-- Added 6 `assert`-based unit tests to `backend/test_json_fixer.py` covering field mapping, NULL coercion (`'` placeholder and empty string), apostrophe escaping, batch splitting, and duplicate `ColliRptNum` / `DO NOTHING` behavior
-- Tests use `backend/seattle short.txt` as a real-data fixture and are runnable via `python test_json_fixer.py` or `pytest`
+- Replaced old fix-JSON form with a functional CrashMap Data Pipeline UI
+- Added Mode dropdown (`Pedestrian` / `Bicyclist`) and Start/End date pickers
+- "Fetch from WSDOT & Download SQL" button calls `POST /api/fetch-and-generate-sql` and triggers a `.sql` file download via Blob URL; filename includes mode and date range
+- Collapsible "Debug: Fix Raw JSON" section retains the original `POST /api/fix-json` workflow
+- Removed unused `json-to-csv-export` / `export-from-json` imports from the form component
+- Bumped version to 0.2.1
 
 ### 2026-02-24 - Implement `POST /api/fetch-and-generate-sql` (Phase 2 complete)
 
@@ -113,6 +118,11 @@ npm run dev
 - Accepts `multipart/form-data` with a `.txt` file upload, `mode`, and optional `batch_size`
 - Runs file content through `fix_malformed_json()` → `generate_sql()` → returns `.sql` as a `Content-Disposition: attachment` file download
 - Returns 400 for missing `mode` or `file`; 500 for JSON parse failures
+
+### 2026-02-24 - Add unit tests for `generate_sql()` (Phase 1 complete)
+
+- Added 6 `assert`-based unit tests to `backend/test_json_fixer.py` covering field mapping, NULL coercion (`'` placeholder and empty string), apostrophe escaping, batch splitting, and duplicate `ColliRptNum` / `DO NOTHING` behavior
+- Tests use `backend/seattle short.txt` as a real-data fixture and are runnable via `python test_json_fixer.py` or `pytest`
 
 ### 2026-02-24 - Implement `generate_sql()` (Phase 1)
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -61,7 +61,7 @@ combined `.sql` file.
 
 ### 1.4 Generate and download
 
-Click **Generate SQL**. The backend will:
+Click **Fetch from WSDOT & Download SQL**. The backend will:
 
 1. Call the WSDOT API for the selected mode and date range
 2. Decode the double-encoded JSON response

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,10 +2,8 @@ import FormComponent from './components/form.component';
 
 function App() {
   return (
-    <div style={{ padding: '20px', textAlign: 'center' }}>
-      <FormComponent
-        onSubmit={(value) => console.log('Form submitted with value:', value)}
-      />
+    <div style={{ padding: '20px' }}>
+      <FormComponent />
     </div>
   );
 }

--- a/frontend/src/components/form.component.tsx
+++ b/frontend/src/components/form.component.tsx
@@ -1,166 +1,214 @@
 import React, { useState } from 'react';
-import csvDownload from 'json-to-csv-export';
-import exportFromJSON from 'export-from-json';
 import './form.styles.css';
 
-interface FormProps {
-  onSubmit?: (value: string) => void;
-}
+const MODES = ['Pedestrian', 'Bicyclist'] as const;
+type Mode = typeof MODES[number];
 
-const FormComponent: React.FC<FormProps> = ({ onSubmit }) => {
-  const [inputValue, setInputValue] = useState<string>('');
+const today = new Date().toISOString().slice(0, 10);
+const startOfYear = `${new Date().getFullYear()}-01-01`;
+
+const FormComponent: React.FC = () => {
+  // Main fetch state
+  const [mode, setMode] = useState<Mode>('Pedestrian');
+  const [startDate, setStartDate] = useState<string>(startOfYear);
+  const [endDate, setEndDate] = useState<string>(today);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const [fetchError, setFetchError] = useState<string>('');
+  const [fetchSuccess, setFetchSuccess] = useState<string>('');
+
+  // Debug section state
+  const [showDebug, setShowDebug] = useState<boolean>(false);
+  const [debugInput, setDebugInput] = useState<string>('');
   const [fixedJson, setFixedJson] = useState<string>('');
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string>('');
+  const [isFixing, setIsFixing] = useState<boolean>(false);
+  const [debugError, setDebugError] = useState<string>('');
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const toApiDate = (d: string) => d.replace(/-/g, '');
+
+  const handleFetch = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!inputValue.trim()) {
-      setError('Please enter some text to fix');
+    if (!startDate || !endDate) {
+      setFetchError('Please select both start and end dates.');
       return;
     }
+    if (startDate > endDate) {
+      setFetchError('Start date must be before end date.');
+      return;
+    }
+    setIsFetching(true);
+    setFetchError('');
+    setFetchSuccess('');
 
-    setIsLoading(true);
-    setError('');
+    try {
+      const response = await fetch('/api/fetch-and-generate-sql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode,
+          start_date: toApiDate(startDate),
+          end_date: toApiDate(endDate),
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({
+          error: `HTTP ${response.status}: ${response.statusText}`,
+        }));
+        throw new Error(errorData.error || `HTTP ${response.status}`);
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `crashmap_${mode.toLowerCase()}_${toApiDate(startDate)}_${toApiDate(endDate)}.sql`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setFetchSuccess('SQL file downloaded successfully.');
+    } catch (err) {
+      setFetchError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  const handleFixJson = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!debugInput.trim()) {
+      setDebugError('Please paste some JSON to fix.');
+      return;
+    }
+    setIsFixing(true);
+    setDebugError('');
     setFixedJson('');
 
     try {
       const response = await fetch('/api/fix-json', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          malformed_json: inputValue
-        })
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ malformed_json: debugInput }),
       });
 
       if (!response.ok) {
-        if (response.status === 404) {
-          throw new Error(
-            'Backend API not found. Make sure the Flask server is running on port 5000.'
-          );
-        }
         const errorData = await response.json().catch(() => ({
-          error: `HTTP ${response.status}: ${response.statusText}`
+          error: `HTTP ${response.status}: ${response.statusText}`,
         }));
-        throw new Error(
-          errorData.error || `HTTP ${response.status}: ${response.statusText}`
-        );
+        throw new Error(errorData.error || `HTTP ${response.status}`);
       }
 
       const data = await response.json();
       setFixedJson(data.fixed_json);
-
-      if (onSubmit) {
-        onSubmit(data.fixed_json);
-      }
-
-      console.log('JSON fixed successfully:', data.fixed_json);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'An error occurred';
-      setError(errorMessage);
-      console.error('Error fixing JSON:', err);
+      setDebugError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
-      setIsLoading(false);
+      setIsFixing(false);
     }
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInputValue(e.target.value);
   };
 
   return (
     <div className="form-container">
-      <div className="layout-wrapper">
-        <div className="form-section">
-          <form onSubmit={handleSubmit} className="simple-form">
+      <h1 className="app-title">CrashMap Data Pipeline</h1>
+      <p className="app-subtitle">
+        Fetch crash data from WSDOT and generate a SQL file for CrashMap import.
+      </p>
+
+      <form onSubmit={handleFetch} className="fetch-form">
+        <div className="field-row">
+          <div className="field-group">
+            <label htmlFor="mode" className="input-label">Mode</label>
+            <select
+              id="mode"
+              value={mode}
+              onChange={(e) => setMode(e.target.value as Mode)}
+              className="text-input"
+            >
+              {MODES.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </div>
+          <div className="field-group">
+            <label htmlFor="startDate" className="input-label">Start Date</label>
+            <input
+              id="startDate"
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="text-input"
+              required
+            />
+          </div>
+          <div className="field-group">
+            <label htmlFor="endDate" className="input-label">End Date</label>
+            <input
+              id="endDate"
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="text-input"
+              required
+            />
+          </div>
+        </div>
+
+        <button type="submit" className="submit-button" disabled={isFetching}>
+          {isFetching ? 'Fetching from WSDOT…' : 'Fetch from WSDOT & Download SQL'}
+        </button>
+
+        {fetchError && <div className="error-message">{fetchError}</div>}
+        {fetchSuccess && <div className="success-message">{fetchSuccess}</div>}
+      </form>
+
+      <div className="debug-section">
+        <button
+          type="button"
+          className="debug-toggle"
+          onClick={() => setShowDebug(!showDebug)}
+        >
+          {showDebug ? '▼' : '▶'} Debug: Fix Raw JSON
+        </button>
+
+        {showDebug && (
+          <form onSubmit={handleFixJson} className="simple-form">
             <div className="input-group">
-              <button
-                type="submit"
-                className="submit-button"
-                disabled={isLoading}
-              >
-                {isLoading ? 'Fixing JSON...' : 'Fix JSON'}
-              </button>
-              <label htmlFor="textInput" className="input-label">
+              <label htmlFor="debugInput" className="input-label">
                 Paste malformed JSON:
               </label>
               <textarea
-                id="textInput"
-                value={inputValue}
-                onChange={handleInputChange}
+                id="debugInput"
+                value={debugInput}
+                onChange={(e) => setDebugInput(e.target.value)}
                 placeholder="Paste your malformed JSON here..."
                 className="text-input"
-                rows={1}
-                style={{
-                  minHeight: '2.5rem',
-                  resize: 'none',
-                  overflow: 'hidden'
-                }}
-                onInput={(e) => {
-                  const target = e.target as HTMLTextAreaElement;
-                  target.style.height = 'auto';
-                  target.style.height = target.scrollHeight + 'px';
-                }}
+                rows={4}
               />
+              <button type="submit" className="submit-button" disabled={isFixing}>
+                {isFixing ? 'Fixing JSON…' : 'Fix JSON'}
+              </button>
             </div>
-            {error && <div className="error-message">{error}</div>}
+            {debugError && <div className="error-message">{debugError}</div>}
+            {fixedJson && (
+              <div className="result-group">
+                <label className="input-label">Fixed JSON:</label>
+                <textarea
+                  value={fixedJson}
+                  readOnly
+                  className="text-input result-textarea"
+                  rows={8}
+                />
+                <button
+                  type="button"
+                  className="copy-button"
+                  onClick={() => navigator.clipboard.writeText(fixedJson)}
+                >
+                  Copy to Clipboard
+                </button>
+              </div>
+            )}
           </form>
-        </div>
-
-        <div className="result-section">
-          {fixedJson && (
-            <div className="result-group">
-              <button
-                type="button"
-                className="copy-button"
-                onClick={() => {
-                  navigator.clipboard.writeText(fixedJson);
-                }}
-              >
-                Copy to Clipboard
-              </button>
-              <button
-                type="button"
-                className="copy-button"
-                onClick={() => {
-                  exportFromJSON({ data: JSON.parse(fixedJson), fileName: 'export', exportType: exportFromJSON.types.txt });
-                }}
-              >
-                Export to .txt File
-              </button>
-              <button
-                type="button"
-                className="copy-button"
-                onClick={() => {
-                  csvDownload({ data: JSON.parse(fixedJson), filename: 'export' });
-                }}
-              >
-                Export to .csv
-              </button>
-              <label className="input-label">Fixed JSON:</label>
-              <textarea
-                value={fixedJson}
-                readOnly
-                className="text-input result-textarea"
-                rows={1}
-                style={{
-                  minHeight: '2.5rem',
-                  resize: 'none',
-                  overflow: 'hidden'
-                }}
-                onFocus={(e) => {
-                  const target = e.target as HTMLTextAreaElement;
-                  target.style.height = 'auto';
-                  target.style.height = target.scrollHeight + 'px';
-                }}
-              />
-            </div>
-          )}
-        </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/form.styles.css
+++ b/frontend/src/components/form.styles.css
@@ -1,10 +1,74 @@
 .form-container {
-  max-width: 1200px;
+  max-width: 800px;
   margin: 2rem auto;
   padding: 2rem;
   background-color: #ffffff;
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.app-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin: 0 0 0.5rem 0;
+  text-align: center;
+}
+
+.app-subtitle {
+  font-size: 1rem;
+  color: #555;
+  margin: 0 0 2rem 0;
+  text-align: center;
+}
+
+.fetch-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.field-row {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-end;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.success-message {
+  padding: 0.75rem;
+  background-color: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.debug-section {
+  margin-top: 2rem;
+  border-top: 1px solid #e1e1e1;
+  padding-top: 1.5rem;
+}
+
+.debug-toggle {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 0.875rem;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.debug-toggle:hover {
+  color: #333;
 }
 
 .layout-wrapper {


### PR DESCRIPTION
- Replaced old fix-JSON form with a functional CrashMap Data Pipeline UI
- Added Mode dropdown (`Pedestrian` / `Bicyclist`) and Start/End date pickers
- "Fetch from WSDOT & Download SQL" button calls `POST /api/fetch-and-generate-sql` and triggers a `.sql` file download via Blob URL; filename includes mode and date range
- Collapsible "Debug: Fix Raw JSON" section retains the original `POST /api/fix-json` workflow
- Removed unused `json-to-csv-export` / `export-from-json` imports from the form component
- Bumped version to 0.2.1

Closes #24 