### PR TITLE
Refactor frontend to use TanStack

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -353,6 +353,7 @@ ON CONFLICT ("ColliRptNum") DO NOTHING;
 | Frontend | React + TypeScript | 18.x / 5.x |
 | Build tool | Vite | 6.x |
 | Styling | TailwindCSS | 3.x |
+| Server state | TanStack Query (`@tanstack/react-query`) | 5.x |
 | Backend | Python + Flask | 3.11 / 2.3 |
 | Production server | Gunicorn | 21.x |
 | Hosting | Render (full-stack) | — |
@@ -515,12 +516,13 @@ phases 1–3 must complete before 4–6.
 | `io` / `werkzeug` | File upload handling (fallback) | Flask provides via `request.files` |
 | `datetime` (stdlib) | Date formatting | For header comment timestamps |
 
-### Frontend (no new npm packages required)
+### Frontend
 
 | Tool | Purpose | Notes |
-|------|---------|-------|
-| `Blob` + `URL.createObjectURL` | SQL file download | Already used pattern for CSV/TXT export |
-| React `useState` | File and mode state | Existing pattern in `form.component.tsx` |
+| --- | --- | --- |
+| `@tanstack/react-query` v5 | Server state, mutation lifecycle | `useMutation` for POST → blob download; `isPending`, `isError`, `isSuccess` replace manual state |
+| `Blob` + `URL.createObjectURL` | SQL file download | Triggered in `onSuccess` callback of `useMutation` |
+| React `useState` | UI-only state (mode, dates, debug toggle) | Existing pattern in `form.component.tsx` |
 
 ### Operator Tools (external)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ npm run dev
 
 ## Changelog
 
+### 2026-02-24 - Refactor frontend to use TanStack Query v5
+
+- Added `@tanstack/react-query` v5 (`useMutation`) for all API calls in `form.component.tsx`
+- Wrapped app root in `QueryClientProvider` in `main.tsx`
+- Replaces manual `isLoading`/`error`/`success` state with `mutation.isPending`, `mutation.isError`, `mutation.isSuccess`, and `mutation.error`
+- `mutationFn` handles the fetch; `onSuccess` callback triggers the blob download
+- Applied to both the primary fetch endpoint and the debug fix-json section
+
 ### 2026-02-24 - Frontend refactor: mode selector + date range pickers (Phase 3, partial)
 
 - Replaced old fix-JSON form with a functional CrashMap Data Pipeline UI

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -53,9 +53,9 @@ In the **Mode** dropdown, select:
 
 Enter a **Start Date** and **End Date**. The WSDOT tool goes back 10 years.
 
-For the initial 10-year backfill, use the **Bulk Import** option and select a start year
-and end year. The pipeline will loop through each year automatically and generate a single
-combined `.sql` file.
+For the initial 10-year backfill, run the import separately for each year range you need.
+A **Bulk Import** mode with a year-range selector is planned for Phase 4 — it will loop
+through each year automatically and generate a single combined `.sql` file.
 
 > **Tip:** For the initial backfill, run Pedestrian for all 10 years first, then Bicyclist.
 
@@ -69,9 +69,11 @@ Click **Fetch from WSDOT & Download SQL**. The backend will:
 4. Generate batched `INSERT ... ON CONFLICT DO NOTHING` statements
 5. Return a `.sql` file download
 
-Review the **preview** (first 50 lines) and **record count** before proceeding.
+The `.sql` file downloads automatically to your browser's default download folder.
+The filename follows the pattern `crashmap_<mode>_<startdate>_<enddate>.sql`
+(e.g. `crashmap_pedestrian_20250101_20251231.sql`).
 
-Click **Download .sql** to save the file (e.g., `crashmap_pedestrian_2015-2024.sql`).
+> **Note:** SQL preview and record count display are planned for a future release.
 
 ### 1.5 Repeat for the other mode
 
@@ -91,8 +93,11 @@ can manually copy the response from the browser and paste it into the pipeline.
 3. Apply your filters (date range, report type) and trigger the data load
 4. Find the `GetPublicPortalData` request in the Network tab
 5. Click it → **Response** tab → select all → copy
-6. In the pipeline, use the **Paste JSON** tab instead of the Fetch tab
-7. Select the correct Mode and proceed as normal
+6. In the pipeline, expand the **Debug: Fix Raw JSON** section and paste the response
+   to confirm the JSON parses correctly
+7. A **Paste / Upload** tab for generating SQL from a pasted response is planned for a
+   future release; in the meantime, use `POST /api/generate-sql` directly via `curl` or
+   a tool like Insomnia/Postman
 
 The raw response is a single line of double-encoded JSON — this is expected.
 
@@ -101,8 +106,8 @@ The raw response is a single line of double-encoded JSON — this is expected.
 ## Stage 2: Generate SQL
 
 Stage 2 is handled automatically inside Stage 1. When you click **Fetch from WSDOT &
-Generate SQL**, the backend fetches the data, decodes the JSON, maps the fields, and
-streams the resulting `.sql` file back to your browser in a single step.
+Download SQL**, the backend fetches the data, decodes the JSON, maps the fields, and
+streams the resulting `.sql` file back to your browser as an automatic download.
 
 There is no separate "generate" step — the download is the output of the fetch.
 
@@ -212,8 +217,7 @@ Use this checklist each time you import new data.
 - [ ] Open CrashMap Data Pipeline
 - [ ] Set Mode = `Pedestrian`
 - [ ] Set date range (e.g. `20250101` – `20251231`; or use Bulk Import for multi-year)
-- [ ] Click **Fetch from WSDOT & Generate SQL** — review preview + record count
-- [ ] Download `.sql` file
+- [ ] Click **Fetch from WSDOT & Download SQL** — file downloads automatically
 - [ ] Run `.sql` against Render PostgreSQL: `psql "$DATABASE_URL" -f <file>.sql`
 - [ ] Confirm insert counts in psql output
 - [ ] Spot-check a record in the database
@@ -223,8 +227,7 @@ Use this checklist each time you import new data.
 - [ ] Open CrashMap Data Pipeline
 - [ ] Set Mode = `Bicyclist`
 - [ ] Set same date range as Pedestrian import
-- [ ] Click **Fetch from WSDOT & Generate SQL** — review preview + record count
-- [ ] Download `.sql` file
+- [ ] Click **Fetch from WSDOT & Download SQL** — file downloads automatically
 - [ ] Run `.sql` against Render PostgreSQL: `psql "$DATABASE_URL" -f <file>.sql`
 - [ ] Confirm insert counts (some `0` rows expected for cross-report duplicates)
 
@@ -329,5 +332,6 @@ npm run dev                # Runs on http://localhost:5173
 
 The Vite dev server proxies `/api/*` requests to the Flask backend automatically.
 
-Test with the included sample file: `backend/seattle short.txt` — select Mode = `Bicyclist`,
-click Generate SQL, and verify the output matches the expected field mapping in `ARCHITECTURE.md`.
+To verify the local setup: select Mode = `Bicyclist`, set a date range, and click
+**Fetch from WSDOT & Download SQL**. Confirm a `.sql` file downloads and the INSERT
+statements match the field mapping in `ARCHITECTURE.md`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.90.21",
         "export-from-json": "^1.7.4",
         "json-to-csv-export": "^3.1.3",
         "react": "^18.3.1",
@@ -72,7 +73,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1324,6 +1324,32 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1389,7 +1415,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1439,7 +1464,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1646,7 +1670,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1967,7 +1990,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2545,7 +2567,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3003,7 +3024,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3193,7 +3213,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3206,7 +3225,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3644,7 +3662,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3766,7 +3783,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3860,7 +3876,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.90.21",
     "export-from-json": "^1.7.4",
     "json-to-csv-export": "^3.1.3",
     "react": "^18.3.1",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import "./styles/global.css";
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-        <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
- Added `@tanstack/react-query` v5 (`useMutation`) for all API calls in `form.component.tsx`
- Wrapped app root in `QueryClientProvider` in `main.tsx`
- Replaces manual `isLoading`/`error`/`success` state with `mutation.isPending`, `mutation.isError`, `mutation.isSuccess`, and `mutation.error`
- `mutationFn` handles the fetch; `onSuccess` callback triggers the blob download
- Applied to both the primary fetch endpoint and the debug fix-json section

Closes #26  