### PR TITLE
Add end-to-end integration tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -319,13 +319,13 @@ ON CONFLICT ("ColliRptNum") DO NOTHING;
 │  │                                                   │   │
 │  │  [Mode ▼]  [Start Date]  [End Date]                 │   │
 │  │                                                   │   │
-│  │  [Fetch from WSDOT & Generate SQL]                │   │
+│  │  [Fetch from WSDOT & Download SQL]                │   │
 │  │                                                   │   │
+│  │  [Debug: Fix Raw JSON ▼]  (collapsible)           │   │
+│  │                                                   │   │
+│  │  ── Planned (Phase 5) ─────────────────────────   │   │
 │  │  Preview: <first 50 lines>   Records: N           │   │
-│  │  [Download .sql]  [Debug: View JSON ▼]            │   │
-│  │                                                   │   │
-│  │  ── Fallback tab ──────────────────────────────   │   │
-│  │  [Paste / Upload raw response]                    │   │
+│  │  [Paste / Upload raw response] (fallback tab)     │   │
 │  └─────────────────────────┬─────────────────────────┘   │
 └────────────────────────────┼────────────────────────────┘
                              │ POST /api/fetch-and-generate-sql
@@ -363,8 +363,9 @@ ON CONFLICT ("ColliRptNum") DO NOTHING;
 
 | File | Role |
 |------|------|
-| `backend/app.py` | Flask app — JSON fixer + SQL generator |
-| `backend/test_json_fixer.py` | Unit tests |
+| `backend/app.py` | Flask app — JSON fixer + SQL generator + API endpoints |
+| `backend/test_json_fixer.py` | Unit tests for `fix_malformed_json()` and `generate_sql()` |
+| `backend/test_e2e.py` | End-to-end integration tests (live WSDOT API, both modes) |
 | `backend/seattle short.txt` | Sample malformed JSON for testing |
 | `frontend/src/components/form.component.tsx` | Main UI component |
 | `render.yaml` | Full-stack Render deployment config |
@@ -405,8 +406,8 @@ Calls the WSDOT API from the backend — no file upload needed.
 **Response 200:**
 
 ```text
-Content-Type: application/sql
-Content-Disposition: attachment; filename="crashmap_import_2026-02-24.sql"
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: attachment; filename="crashmap_import_pedestrian_20260224.sql"
 
 <SQL file content>
 ```

--- a/README.md
+++ b/README.md
@@ -1,28 +1,31 @@
-# ESRI Exporter
+# CrashMap Data Pipeline
 
-**Version:** 0.3.1
+**Version:** 0.3.2
 
-An application for capturing and converting map data from ESRI map applications. Currently, this application works just for capturing crash data from the WSDOT ESRI map for the purposed of reusing the data in a more full-featured app I'm building called CrashMap.
+A full-stack web tool for importing Washington State crash data from the WSDOT collision
+REST API into CrashMap's PostgreSQL database.
 
-WSDOT Map:
+WSDOT data source:
 <https://remoteapps.wsdot.wa.gov/highwaysafety/collision/data/portal/public/>
 
-CrashMap:
+CrashMap (destination):
 <https://github.com/nickmagruder/crashmap>
 
-The application follows a full-stack monorepo structure with a React/TypeScript frontend (built with Vite and styled with Tailwind CSS) and a Python Flask backend. The two layers communicate via a REST API: a Vite dev proxy routes `/api` requests to Flask during development, keeping the frontend and backend independently deployable. The frontend uses functional React components with local `useState` hooks for form state. No global state manager is needed given the single-feature scope. The core backend logic is a JSON normalization pipeline that unwraps the double-encoded, over-escaped JSON that ESRI map exports produce, returning clean, human-readable output suitable for downstream use.
+The pipeline calls the WSDOT API directly from the backend — no browser copy-paste required.
+The operator selects a mode (Pedestrian or Bicyclist) and date range in the UI, the backend
+fetches and decodes the double-encoded JSON response, maps all fields to CrashMap's schema,
+and returns a `.sql` file for the operator to run against the Render PostgreSQL database.
 
-## Built starting with the Python-React Starter Kit
+The stack is a React 18 + TypeScript frontend (Vite, TailwindCSS, TanStack Query v5) with a
+Python 3.11 + Flask 2.3 backend. No direct database connection — output is always a portable
+`.sql` file. See `ARCHITECTURE.md` for technical details and `TUTORIAL.md` for the import runbook.
 
-A simple template for building full-stack applications with Python and React.
+## Stack
 
-## Features
-
-- **Backend**: Flask (Python)
-- **Frontend**: React
-- **Tooling**: Vite for fast frontend builds
-- **Styling**: TailwindCSS
-- **Clean Code**: ESLint
+- **Backend**: Python 3.11 + Flask 2.3 (Gunicorn in production)
+- **Frontend**: React 18 + TypeScript + TanStack Query v5
+- **Tooling**: Vite + TailwindCSS + ESLint
+- **Hosting**: Render (full-stack, `render.yaml` in repo root)
 
 ## Getting Started
 
@@ -93,6 +96,13 @@ npm run dev
 - Frontend: **<http://127.0.0.1:5173>**
 
 ## Changelog
+
+### 2026-02-24 - Add end-to-end integration tests for both modes (Phase 4)
+
+- Added `backend/test_e2e.py` with 10 live-API integration tests covering both Pedestrian and Bicyclist modes
+- Tests cover: WSDOT API reachability, JSON parse + field key validation, full pipeline SQL structure, ColliRptNum integrity, and CrashDate format
+- Run with `python test_e2e.py` or `pytest test_e2e.py -v` from the `backend/` directory (venv active, network access required)
+- Bumped version to 0.3.2
 
 ### 2026-02-24 - Fix CityName null coercion for WSDOT placeholder value
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -54,7 +54,7 @@ In the **Mode** dropdown, select:
 Enter a **Start Date** and **End Date**. The WSDOT tool goes back 10 years.
 
 For the initial 10-year backfill, run the import separately for each year range you need.
-A **Bulk Import** mode with a year-range selector is planned for Phase 4 — it will loop
+A **Bulk Import** mode with a year-range selector is planned for Phase 5.1 — it will loop
 through each year automatically and generate a single combined `.sql` file.
 
 > **Tip:** For the initial backfill, run Pedestrian for all 10 years first, then Bicyclist.

--- a/backend/test_e2e.py
+++ b/backend/test_e2e.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""End-to-end integration tests: live WSDOT API calls for both modes.
+
+These tests make real HTTP requests to the WSDOT collision API and validate
+the full pipeline: API fetch → fix_malformed_json → generate_sql.
+
+Run all e2e tests:
+    pytest test_e2e.py -v
+
+Run directly:
+    python test_e2e.py
+"""
+
+import json
+import requests
+from app import fix_malformed_json, generate_sql
+
+# Narrow date window (one month) keeps response size small (~50–200 records/mode).
+START_DATE = "20250101"
+END_DATE   = "20250131"
+
+_WSDOT_BASE_URL = (
+    "https://remoteapps.wsdot.wa.gov/highwaysafety/collision/data/portal/public/"
+    "CrashDataPortalService.svc/REST/GetPublicPortalData"
+)
+_WSDOT_PARAMS_BASE = {
+    "rptCategory": "Pedestrians and Pedacyclists",
+    "locationType": "",
+    "locationName": "",
+    "jurisdiction": "",
+    "reportStartDate": START_DATE,
+    "reportEndDate":   END_DATE,
+}
+_WSDOT_RPT_NAME = {
+    "Pedestrian": "Pedestrians by Injury Type",
+    "Bicyclist":  "Bicyclists by Injury Type",
+}
+
+# Keys every WSDOT record is expected to contain.
+EXPECTED_KEYS = {
+    "ColliRptNum", "Jurisdiction", "RegionName", "CountyName",
+    "CityName", "FullDate", "FullTime", "MostSevereInjuryType",
+    "AgeGroup", "InvolvedPersons", "Latitude", "Longitude",
+}
+
+
+def _fetch_records(mode):
+    """Fetch WSDOT data for *mode* and return the parsed list of record dicts."""
+    params = {**_WSDOT_PARAMS_BASE, "rptName": _WSDOT_RPT_NAME[mode]}
+    resp = requests.get(_WSDOT_BASE_URL, params=params, timeout=60)
+    resp.raise_for_status()
+    fixed = fix_malformed_json(resp.text)
+    return json.loads(fixed)
+
+
+# ---------------------------------------------------------------------------
+# Reachability
+# ---------------------------------------------------------------------------
+
+def test_e2e_pedestrian_api_reachable():
+    """Pedestrian WSDOT endpoint returns HTTP 200 with a non-empty body."""
+    params = {**_WSDOT_PARAMS_BASE, "rptName": _WSDOT_RPT_NAME["Pedestrian"]}
+    resp = requests.get(_WSDOT_BASE_URL, params=params, timeout=60)
+    assert resp.status_code == 200, f"Unexpected status: {resp.status_code}"
+    assert len(resp.text) > 0, "Response body is empty"
+
+
+def test_e2e_bicyclist_api_reachable():
+    """Bicyclist WSDOT endpoint returns HTTP 200 with a non-empty body."""
+    params = {**_WSDOT_PARAMS_BASE, "rptName": _WSDOT_RPT_NAME["Bicyclist"]}
+    resp = requests.get(_WSDOT_BASE_URL, params=params, timeout=60)
+    assert resp.status_code == 200, f"Unexpected status: {resp.status_code}"
+    assert len(resp.text) > 0, "Response body is empty"
+
+
+# ---------------------------------------------------------------------------
+# Parse / field validation
+# ---------------------------------------------------------------------------
+
+def test_e2e_pedestrian_parse():
+    """Pedestrian response parses to a non-empty list of dicts with all expected keys."""
+    records = _fetch_records("Pedestrian")
+    assert isinstance(records, list), "Parsed data is not a list"
+    assert len(records) > 0, "No records returned for Pedestrian / Jan 2025"
+    for key in EXPECTED_KEYS:
+        assert key in records[0], f"First record missing key: {key}"
+
+
+def test_e2e_bicyclist_parse():
+    """Bicyclist response parses to a non-empty list of dicts with all expected keys."""
+    records = _fetch_records("Bicyclist")
+    assert isinstance(records, list), "Parsed data is not a list"
+    assert len(records) > 0, "No records returned for Bicyclist / Jan 2025"
+    for key in EXPECTED_KEYS:
+        assert key in records[0], f"First record missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline: API → parse → generate_sql
+# ---------------------------------------------------------------------------
+
+def _assert_sql_structure(sql, mode, record_count):
+    """Shared structural assertions for generated SQL."""
+    assert f"-- Mode: {mode}" in sql
+    assert f"-- Records: {record_count}" in sql
+    assert "INSERT INTO crashdata" in sql
+
+    # Required columns (double-quoted PascalCase)
+    for col in ('"ColliRptNum"', '"Jurisdiction"', '"StateOrProvinceName"',
+                '"RegionName"', '"CountyName"', '"CityName"', '"FullDate"',
+                '"CrashDate"', '"FullTime"', '"MostSevereInjuryType"',
+                '"AgeGroup"', '"InvolvedPersons"', '"Latitude"', '"Longitude"',
+                '"Mode"', '"geom"'):
+        assert col in sql, f"Column missing from INSERT: {col}"
+
+    # Hardcoded fields
+    assert "'Washington'" in sql          # StateOrProvinceName
+    assert f"'{mode}'" in sql            # Mode stamped from UI selection
+    assert "ST_SetSRID(ST_MakePoint(" in sql  # PostGIS geometry
+
+    # Conflict clause
+    assert 'ON CONFLICT ("ColliRptNum") DO NOTHING' in sql
+    assert "DO UPDATE" not in sql
+
+    # Dropped columns must never appear
+    assert "CrashStatePlaneX" not in sql
+    assert "CrashStatePlaneY" not in sql
+
+
+def test_e2e_pedestrian_generate_sql():
+    """Pedestrian pipeline: API → parse → generate_sql produces structurally valid SQL."""
+    records = _fetch_records("Pedestrian")
+    sql = generate_sql(records, mode="Pedestrian")
+    _assert_sql_structure(sql, "Pedestrian", len(records))
+
+
+def test_e2e_bicyclist_generate_sql():
+    """Bicyclist pipeline: API → parse → generate_sql produces structurally valid SQL."""
+    records = _fetch_records("Bicyclist")
+    sql = generate_sql(records, mode="Bicyclist")
+    _assert_sql_structure(sql, "Bicyclist", len(records))
+
+
+# ---------------------------------------------------------------------------
+# Record integrity
+# ---------------------------------------------------------------------------
+
+def test_e2e_pedestrian_all_collirptnums_present():
+    """Every ColliRptNum from the Pedestrian API response appears in the SQL output."""
+    records = _fetch_records("Pedestrian")
+    sql = generate_sql(records, mode="Pedestrian")
+    missing = [r["ColliRptNum"] for r in records if f"'{r['ColliRptNum']}'" not in sql]
+    assert not missing, f"ColliRptNums missing from SQL: {missing[:5]}"
+
+
+def test_e2e_bicyclist_all_collirptnums_present():
+    """Every ColliRptNum from the Bicyclist API response appears in the SQL output."""
+    records = _fetch_records("Bicyclist")
+    sql = generate_sql(records, mode="Bicyclist")
+    missing = [r["ColliRptNum"] for r in records if f"'{r['ColliRptNum']}'" not in sql]
+    assert not missing, f"ColliRptNums missing from SQL: {missing[:5]}"
+
+
+def test_e2e_pedestrian_crash_date_format():
+    """CrashDate values in SQL are YYYY-MM-DD (10-char date slice from FullDate)."""
+    records = _fetch_records("Pedestrian")
+    sql = generate_sql(records, mode="Pedestrian")
+    # Spot-check first record: CrashDate should be the first 10 chars of FullDate
+    first = records[0]
+    expected_crash_date = str(first["FullDate"])[:10]
+    assert f"'{expected_crash_date}'" in sql, (
+        f"CrashDate '{expected_crash_date}' not found in SQL"
+    )
+
+
+def test_e2e_bicyclist_crash_date_format():
+    """CrashDate values in SQL are YYYY-MM-DD (10-char date slice from FullDate)."""
+    records = _fetch_records("Bicyclist")
+    sql = generate_sql(records, mode="Bicyclist")
+    first = records[0]
+    expected_crash_date = str(first["FullDate"])[:10]
+    assert f"'{expected_crash_date}'" in sql, (
+        f"CrashDate '{expected_crash_date}' not found in SQL"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point for direct execution
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    tests = [
+        test_e2e_pedestrian_api_reachable,
+        test_e2e_bicyclist_api_reachable,
+        test_e2e_pedestrian_parse,
+        test_e2e_bicyclist_parse,
+        test_e2e_pedestrian_generate_sql,
+        test_e2e_bicyclist_generate_sql,
+        test_e2e_pedestrian_all_collirptnums_present,
+        test_e2e_bicyclist_all_collirptnums_present,
+        test_e2e_pedestrian_crash_date_format,
+        test_e2e_bicyclist_crash_date_format,
+    ]
+
+    passed = 0
+    failed = 0
+    for test_fn in tests:
+        try:
+            test_fn()
+            print(f"PASS  {test_fn.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL  {test_fn.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"ERROR {test_fn.__name__}: {e}")
+            failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")


### PR DESCRIPTION
- Added `backend/test_e2e.py` with 10 live-API integration tests covering both Pedestrian and Bicyclist modes
- Tests cover: WSDOT API reachability, JSON parse + field key validation, full pipeline SQL structure, ColliRptNum integrity, and CrashDate format
- Run with `python test_e2e.py` or `pytest test_e2e.py -v` from the `backend/` directory (venv active, network access required)
- Bumped version to 0.3.2

Closes #30 